### PR TITLE
Rigctld nolaunch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 #    Public License along with TR log for linux.  If not, see
 #<http://www.gnu.org/licenses/>.
 
-RELEASE=0.52
+RELEASE=0.53
 
 all:
 	test 2 -eq `grep -c "Linux $(RELEASE)" src/versions.inc`

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -16,6 +16,11 @@ You should have received a copy of the GNU General
     Public License along with TR log for linux.  If not, see
 <http://www.gnu.org/licenses/>.
 
+0.53
+- Updated score reporter URL.
+- Allow control of the launch of rigctld. If only the port is given rigctld
+  commands are are sent/received to/from port, but rigctld is not launched
+  by TR.
 
 0.52 
 - This is the first release done by N6TR instead of W9CF

--- a/doc/trloglinux.tex
+++ b/doc/trloglinux.tex
@@ -941,6 +941,14 @@ The hamlib recommended rigctld port are the even numbered ports
 4532, 4534, 4536, etc. You can,
 of course, use any unused nonprivileged port.
 
+If you want TR to connect to a rigctld that is or will be started by
+another process, then leave out everything excecpt the port number, i.e.
+\begin{verbatim}
+radio one type = rigctld;4532;
+\end{verbatim}
+will set up TR to communicate with rigctld commands on port 4532 but
+will not launch rigctld.
+
 \section{Real time contest score reporting}
 TR can report contest scores and band breakdowns to one of the contest
 scoreboards if desired. Currently, this is not user friendly at all.

--- a/src/communication.pas
+++ b/src/communication.pas
@@ -221,17 +221,11 @@ begin
       end
    else if pos('RIGCTLD',upcase(devicename)) = 1 then
       begin
-writeln(stderr,'devicename =',devicename);
          temp := devicename;
-writeln(stderr,'temp 0 =',temp);
          delete(temp,1,8);
-writeln(stderr,'temp 1 =',temp);
          colonpos := pos(';',temp);
          delete(temp,1,colonpos);
-writeln(stderr,'temp 2 =',temp);
          launch := not (temp = '');
-writeln(stderr,'launch =',launch);
-flush(stderr);
          if launch then
          begin
             if (fpsystem('which rigctld > /dev/null 2>&1') <> 0) then
@@ -420,18 +414,13 @@ begin
    if (pid2 = 0) then
    begin
       diewithparent;
-writeln(stderr,'launch in rigctldforkn  =',launch);
       if not launch then
       begin
          temp := dev;
-writeln(stderr,'temp 0 =',temp);
          delete(temp,1,8);
-writeln(stderr,'temp 1 =',temp);
          colonpos := pos(';',temp);
          ncport := copy(temp,1,colonpos-1);
-writeln(stderr,'ncport =',ncport);
       end;
-flush(stderr);
       fdslave := fpopen(slave,O_RDWR);
       fpclose(0);
       fpclose(1);

--- a/src/communication.pas
+++ b/src/communication.pas
@@ -221,12 +221,17 @@ begin
       end
    else if pos('RIGCTLD',upcase(devicename)) = 1 then
       begin
+writeln(stderr,'devicename =',devicename);
          temp := devicename;
+writeln(stderr,'temp 0 =',temp);
          delete(temp,1,8);
+writeln(stderr,'temp 1 =',temp);
          colonpos := pos(';',temp);
          delete(temp,1,colonpos);
-         colonpos := pos(';',temp);
+writeln(stderr,'temp 2 =',temp);
          launch := not (temp = '');
+writeln(stderr,'launch =',launch);
+flush(stderr);
          if launch then
          begin
             if (fpsystem('which rigctld > /dev/null 2>&1') <> 0) then
@@ -415,13 +420,18 @@ begin
    if (pid2 = 0) then
    begin
       diewithparent;
+writeln(stderr,'launch in rigctldforkn  =',launch);
       if not launch then
       begin
          temp := dev;
+writeln(stderr,'temp 0 =',temp);
          delete(temp,1,8);
+writeln(stderr,'temp 1 =',temp);
          colonpos := pos(';',temp);
          ncport := copy(temp,1,colonpos-1);
+writeln(stderr,'ncport =',ncport);
       end;
+flush(stderr);
       fdslave := fpopen(slave,O_RDWR);
       fpclose(0);
       fpclose(1);

--- a/src/communication.pas
+++ b/src/communication.pas
@@ -226,7 +226,7 @@ begin
          colonpos := pos(';',temp);
          delete(temp,1,colonpos);
          colonpos := pos(';',temp);
-         launch := not (copy(temp,1,colonpos-1) = 'NONE');
+         launch := not (temp = '');
          if launch then
          begin
             if (fpsystem('which rigctld > /dev/null 2>&1') <> 0) then
@@ -408,11 +408,20 @@ end;
 
 procedure serialportx.rigctldforkn;
 var fdslave: longint;
+    temp: ansistring;
+    colonpos: longint;
 begin
    pid2 := fpfork;
    if (pid2 = 0) then
    begin
       diewithparent;
+      if not launch then
+      begin
+         temp := dev;
+         delete(temp,1,8);
+         colonpos := pos(';',temp);
+         ncport := copy(temp,1,colonpos-1);
+      end;
       fdslave := fpopen(slave,O_RDWR);
       fpclose(0);
       fpclose(1);

--- a/src/communication.pas
+++ b/src/communication.pas
@@ -61,6 +61,7 @@ type
        dev: string;
        ncport: ansistring;
        inverted: boolean;
+       launch: boolean;
        procedure readbuf;
        procedure shellfork;
        procedure ncatforkr;
@@ -168,6 +169,8 @@ constructor serialportx.create(devicename: string);
 var tempfile: text;
     tios: termios;
     sset: serial_struct;
+    temp: ansistring;
+    colonpos: longint;
 //    rc: longint;
 //    i,flags: integer;
 begin
@@ -218,10 +221,19 @@ begin
       end
    else if pos('RIGCTLD',upcase(devicename)) = 1 then
       begin
-         if (fpsystem('which rigctld > /dev/null 2>&1') <> 0) then
+         temp := devicename;
+         delete(temp,1,8);
+         colonpos := pos(';',temp);
+         delete(temp,1,colonpos);
+         colonpos := pos(';',temp);
+         launch := not (copy(temp,1,colonpos-1) = 'NONE');
+         if launch then
          begin
-            writeln('rigctld command not found -- exiting');
-            halt;
+            if (fpsystem('which rigctld > /dev/null 2>&1') <> 0) then
+            begin
+               writeln('rigctld command not found -- exiting');
+               halt;
+            end;
          end;
          dev := devicename;
          fd := getpt;
@@ -230,8 +242,11 @@ begin
          setlength(slave,200);
          ptsname_r(fd,@slave[1],200);
          setlength(slave,strlen(pchar(@slave[0])));
-         rigctldforkr;
-         delay(100);
+         if launch then
+         begin
+            rigctldforkr;
+            delay(100);
+         end;
          rigctldforkn;
       end
    else
@@ -460,7 +475,10 @@ begin
    begin
       if (pid <> 0) then
       begin
-         if (fpwaitpid(pid,status,WNOHANG) = pid) then rigctldforkr;
+         if launch then
+         begin
+            if (fpwaitpid(pid,status,WNOHANG) = pid) then rigctldforkr;
+         end;
       end;
       if (pid2 <> 0) then
       begin

--- a/src/rigctld.pas
+++ b/src/rigctld.pas
@@ -62,7 +62,8 @@ begin
    inherited create(debugin);
    commandtime := 500;
    commandcount := 0;
-   commandmaxretry := 2;
+//   commandmaxretry := 2;
+   commandmaxretry := -1; //No retries -- problems with misbehaving rigctld
    commandretrycount := 0;
    ignorefreq := false;
    ignorefreqcount := 0;

--- a/src/versions.inc
+++ b/src/versions.inc
@@ -1,3 +1,3 @@
 //based on DOS TR 6.76
-CONST Version = 'Linux 0.52';
+CONST Version = 'Linux 0.52+nolaunch';
       PostVersion = 'Linux 0.52';

--- a/src/versions.inc
+++ b/src/versions.inc
@@ -1,3 +1,3 @@
 //based on DOS TR 6.76
-CONST Version = 'Linux 0.52+nolaunch';
-      PostVersion = 'Linux 0.52';
+CONST Version = 'Linux 0.53';
+      PostVersion = 'Linux 0.53';


### PR DESCRIPTION
This adds code to inhibit launching of rigctld if it has been or will be launched externally. This fixes N5OE's problem with his SDR. I updated the release notes and bumped the version to 0.53, so if you two approve, I can trigger a new release.