### PR TITLE
Enable SO_BROADCAST on UDP output sockets

### DIFF
--- a/src/tree.pas
+++ b/src/tree.pas
@@ -5166,9 +5166,14 @@ FUNCTION OpenUDPPortForOutput (IPAddress: STRING; PortNumber: LONGINT; VAR Socke
 
 VAR SocketAddr: TINetSockAddr;
     ConnectResult: INTEGER;
+    BroadcastEnable: LongInt;
 
     BEGIN
     Socket := fpSocket (AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+
+    BroadcastEnable := 1;
+    fpsetsockopt (Socket, SOL_SOCKET, SO_BROADCAST, @BroadcastEnable, SizeOf(BroadcastEnable));
+
     SocketAddr.sin_family := AF_INET;
     SocketAddr.sin_port := htons (PortNumber);
     SocketAddr.sin_addr := StrToNetAddr (IPAddress);


### PR DESCRIPTION
Currently, when you set `QSO UDP IP` for UDP QSO output to a broadcast IP (e.g. `192.168.0.255`), the program crashes when attempting to open the socket.

This sets the `SO_BROADCAST` flag when creating a socket for UDP output, which allows a broadcast address to be specified without error. This has no effect on non-broadcast addresses.

```
       SO_BROADCAST
              Set or get the broadcast flag.  When enabled, datagram
              sockets are allowed to send packets to a broadcast address.
              This option has no effect on stream-oriented sockets.
```